### PR TITLE
Split CALENDARS constant in multiple lines

### DIFF
--- a/lib/spok/workday.rb
+++ b/lib/spok/workday.rb
@@ -9,7 +9,13 @@ class Spok
   # module.
   module Workday
     # Public: Array of available calendars.
-    CALENDARS = %i(brasil bovespa portugal vietnam poland)
+    CALENDARS = %i(
+      brasil
+      bovespa
+      portugal
+      vietnam
+      poland
+    )
 
     # Public: Hash containing all holidays for each available calendar.
     HOLIDAYS = CALENDARS.map do |calendar|


### PR DESCRIPTION
This was made in order to avoid conflicts when adding new calendars
to the gem.