### PR TITLE
Add Workday API available via Spok.

### DIFF
--- a/lib/spok.rb
+++ b/lib/spok.rb
@@ -170,6 +170,96 @@ class Spok
     ((@end_date - @start_date).to_f / 365).to_f.round(1)
   end
 
+  # Public: Checks if a given day is a restday.
+  #
+  # date     - The Date to be checked.
+  # calendar - Symbol informing in which calendar the date will be checked
+  #            (default: :brasil).
+  #
+  # Examples
+  #
+  #   Spok.restday?(Date.new(2012, 8, 6))
+  #   # => false
+  #
+  # Returns a boolean.
+  def self.restday?(date, calendar: Spok.default_calendar)
+    Workday.restday?(date, calendar: calendar)
+  end
+
+  # Public: Checks if a given day is a workday.
+  #
+  # date     - The Date to be checked.
+  # calendar - Symbol informing in which calendar the date will be checked
+  #            (default: :brasil).
+  #
+  # Examples
+  #
+  #   Spok.workday?(Date.new(2012, 8, 6))
+  #   # => true
+  #
+  # Returns a boolean.
+  def self.workday?(date, calendar: Spok.default_calendar)
+    Workday.workday?(date, calendar: calendar)
+  end
+
+  # Public: Checks if a given Date is on a weekend.
+  #
+  # date - The Date to be checked.
+  #
+  # Examples
+  #
+  #   Spok.weekend?(Date.new(2012, 8, 6))
+  #   # => false
+  #
+  # Returns a boolean.
+  def self.weekend?(date)
+    Workday.weekend?(date)
+  end
+
+  # Public: Checks if a given Date is on a holiday.
+  #
+  # date     - The Date to be checked.
+  # calendar - Symbol informing in which calendar the date will be checked
+  #            (default: :brasil).
+  #
+  # Examples
+  #
+  #   Spok.holiday?(Date.new(2012, 5, 1))
+  #   # => true
+  #
+  # Returns a boolean.
+  def self.holiday?(date, calendar: Spok.default_calendar)
+    Workday.holiday?(date, calendar: calendar)
+  end
+
+  # Public: Returns the last workday until the informed date.
+  # It returns the informed date in case it is a workday.
+  #
+  # date     - End Date to check for workdays.
+  # calendar - Symbol informing in which calendar to check for workdays
+  #            (default: :brasil).
+  #
+  # Examples
+  #   Spok.last_workday(Date.new(2012, 10, 21))
+  #   # => #<Date: 2012-10-19 ((2456220j,0s,0n),+0s,2299161j)>
+  def self.last_workday(date, calendar: Spok.default_calendar)
+    Workday.last_workday(date, calendar: calendar)
+  end
+
+  # Public: Returns the next workday starting from the informed date.
+  # It returns the informed date in case it is a workday.
+  #
+  # date     - Start Date to check for workdays.
+  # calendar - Symbol informing in which calendar to check for workdays
+  #            (default: :brasil).
+  #
+  # Examples
+  #   Spok.next_workday(Date.new(2012, 10, 21))
+  #   # => #<Date: 2012-10-19 ((2456220j,0s,0n),+0s,2299161j)>
+  def self.next_workday(date, calendar: Spok.default_calendar)
+    Workday.next_workday(date, calendar: calendar)
+  end
+
   # Public: Compares the Spok with other Spok. Two spoks are considered
   # equal when they are both instances of Spok, and have the same start and
   # end dates.

--- a/spec/lib/spok/public_api_spec.rb
+++ b/spec/lib/spok/public_api_spec.rb
@@ -1,0 +1,226 @@
+require 'spec_helper'
+require 'spok/workday'
+
+describe Spok do
+  describe '#workday?' do
+    context 'monday' do
+      it 'is a workday' do
+        expect(described_class.workday?(Date.new(2012, 8, 6))).to eq(true)
+      end
+    end
+
+    context 'saturday' do
+      it 'is not a workday' do
+        expect(described_class.workday?(Date.new(2012, 8, 4))).to eq(false)
+      end
+    end
+
+    context 'sunday' do
+      it 'is not a workday' do
+        expect(described_class.workday?(Date.new(2012, 8, 5))).to eq(false)
+      end
+    end
+
+    context 'holidays using brasil calendar' do
+      it 'is not a workday' do
+        ['2012-06-07', '2012-09-07', '2012-10-12',
+         '2012-11-02', '2012-11-15', '2012-12-25'].each do |holiday|
+          expect(described_class.workday?(Date.parse(holiday))).to eq(false)
+        end
+      end
+    end
+
+    context 'holidays using bovespa calendar' do
+      it 'is not a workday' do
+        ['2012-07-09', '2012-11-20', '2012-12-24'].each do |holiday|
+          expect(described_class.workday?(Date.parse(holiday), calendar: :bovespa)).to eq(false)
+        end
+      end
+    end
+
+    context 'days using spanish calendar' do
+      it 'is not a workday' do
+        ['2009-01-06', '2009-04-10', '2009-04-12'].each do |holiday|
+          expect(described_class.workday?(Date.parse(holiday), calendar: :spain)).to eq(false)
+        end
+      end
+
+      it 'is a workday' do
+        ['2009-01-07', '2019-01-14', '2020-04-22'].each do |workday|
+          expect(described_class.workday?(Date.parse(workday), calendar: :spain)).to eq(true)
+        end
+      end
+    end
+
+    context 'days using dutch calendar' do
+      it 'is not a workday' do
+        ['2019-06-10', '2019-12-25', '2019-12-26'].each do |holiday|
+          expect(described_class.workday?(Date.parse(holiday), calendar: :netherlands)).to eq(false)
+        end
+      end
+
+      it 'is a workday' do
+        ['2010-06-10', '2009-09-11', '2019-12-02'].each do |workday|
+          expect(described_class.workday?(Date.parse(workday), calendar: :netherlands)).to eq(true)
+        end
+      end
+    end
+  end
+
+  describe '#restday?' do
+    context 'Using Date objects' do
+      context 'monday' do
+        it 'is not a restday' do
+          expect(described_class.restday?(Date.new(2012, 8, 6))).to eq(false)
+        end
+      end
+
+      context 'saturday' do
+        it 'is a restday' do
+          expect(described_class.restday?(Date.new(2012, 8, 4))).to eq(true)
+        end
+      end
+
+      context 'sunday' do
+        it 'is a restday' do
+          expect(described_class.restday?(Date.new(2012, 8, 5))).to eq(true)
+        end
+      end
+
+      context 'holiday' do
+        [
+          Date.new(2012, 6, 07),
+          Date.new(2012, 9, 07),
+          Date.new(2012, 10, 12),
+          Date.new(2012, 11, 02),
+          Date.new(2012, 11, 15),
+          Date.new(2012, 12, 25)
+        ].each do |holiday|
+          it 'is a restday' do
+            expect(described_class.restday?(holiday)).to eq(true)
+          end
+        end
+      end
+    end
+
+    context 'using DateTime objects' do
+      context 'monday' do
+        it 'is not a restday' do
+          expect(described_class.restday?(DateTime.new(2012, 8, 6, 12))).to eq(false)
+        end
+      end
+
+      context 'saturday' do
+        it 'is a restday' do
+          expect(described_class.restday?(DateTime.new(2012, 8, 4, 12))).to eq(true)
+        end
+      end
+
+      context 'sunday' do
+        it 'is a restday' do
+          expect(described_class.restday?(DateTime.new(2012, 8, 5, 13))).to eq(true)
+        end
+      end
+
+      context 'holiday' do
+        [
+          DateTime.new(2017, 01, 01, 00),
+          DateTime.new(2017, 10, 12, 01),
+          DateTime.new(2017, 11, 02, 02),
+          DateTime.new(2017, 11, 15, 03),
+          DateTime.new(2017, 12, 25, 04)
+        ].each do |holiday|
+          it 'is a restday' do
+            expect(described_class.restday?(holiday)).to eq(true)
+          end
+        end
+      end
+    end
+  end
+
+  describe '#weekend?' do
+    it 'returns true when date is a Saturday' do
+      expect(described_class.weekend?(Date.new(2018, 8, 11))).to eq(true)
+    end
+
+    it 'returns true when date is a Sunday' do
+      expect(described_class.weekend?(Date.new(2018, 8, 12))).to eq(true)
+    end
+
+    it 'returns false when date is not a Saturday or Sunday' do
+      expect(described_class.weekend?(Date.new(2018, 8, 13))).to eq(false)
+      expect(described_class.weekend?(Date.new(2018, 8, 14))).to eq(false)
+      expect(described_class.weekend?(Date.new(2018, 8, 15))).to eq(false)
+      expect(described_class.weekend?(Date.new(2018, 8, 16))).to eq(false)
+      expect(described_class.weekend?(Date.new(2018, 8, 17))).to eq(false)
+    end
+  end
+
+  describe '#holiday?' do
+    it 'returns false when date is not a holiday on the given calendar' do
+      expect(described_class.holiday?(Date.new(2018, 05, 02), calendar: :brasil)).to eq(false)
+      expect(described_class.holiday?(Date.new(2018, 12, 15), calendar: :bovespa)).to eq(false)
+    end
+
+    it 'returns true when date is a holiday on the given calendar' do
+      expect(described_class.holiday?(Date.new(2018, 05, 01), calendar: :brasil)).to eq(true)
+      expect(described_class.holiday?(Date.new(2018, 12, 25), calendar: :bovespa)).to eq(true)
+    end
+  end
+
+  describe '#last_workday' do
+    context 'when date is 2012-10-25 (Thursday)' do
+      it 'returns the same date' do
+        expect(described_class.last_workday(Date.new(2012, 10, 25))).to eq(Date.new(2012, 10, 25))
+      end
+    end
+
+    context 'when date is 2012-10-21 (Sunday)' do
+      it 'returns 2012-10-19 (Friday)' do
+        expect(described_class.last_workday(Date.new(2012, 10, 21))).to eq(Date.new(2012, 10, 19))
+      end
+    end
+
+    context 'when date is 2012-10-20 (Saturday)' do
+      it 'returns 2012-10-19 (Friday)' do
+        expect(described_class.last_workday(Date.new(2012, 10, 20))).to eq(Date.new(2012, 10, 19))
+      end
+    end
+
+    context 'when bovespa calendar' do
+      context 'when date is 2013-01-01 (bovespa holiday)' do
+        it 'returns 2012-12-30,  because 2012-12-31 is also a bovespa holiday and 2012-01-30|29 is a weekend' do
+          expect(described_class.last_workday(Date.new(2013, 1, 1), calendar: :bovespa)).to eq(Date.new(2012, 12, 28))
+        end
+      end
+    end
+  end
+
+  describe '#next_workday' do
+    context 'when date is 2012-10-26 (Friday)' do
+      it 'returns the same date' do
+        expect(described_class.next_workday(Date.new(2012, 10, 26))).to eq(Date.new(2012, 10, 26))
+      end
+    end
+
+    context 'when date is 2012-10-21 (Sunday)' do
+      it 'returns 2012-10-22 (Monday)' do
+        expect(described_class.next_workday(Date.new(2012, 10, 21))).to eq(Date.new(2012, 10, 22))
+      end
+    end
+
+    context 'when date is 2012-10-20 (Saturday)' do
+      it 'returns 2012-10-22 (Monday)' do
+        expect(described_class.next_workday(Date.new(2012, 10, 20))).to eq(Date.new(2012, 10, 22))
+      end
+    end
+
+    context 'when bovespa calendar' do
+      context 'when date is 2012-12-30 (sunday)' do
+        it 'returns 2013-01-02, because 2012, 12, 31 and 2013-01-01 are bovespa holidays' do
+          expect(described_class.next_workday(Date.new(2012, 12, 30), calendar: :bovespa)).to eq(Date.new(2013, 1, 2))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit allows to invoke the inner Workday class via the Spok public API as previously discussed in #25.

We can do this in some other ways. Here's a few possible solutions:

 - Implement `Workday` as a `module` and include it in `Spok`.
- Implement the `method_missing` method and proxy all calls to `Workday`. But I fear this solution might not be desirable (or will need to be modified to work as intended).

The proposed solution in this PR, although might have a bit of duplication, it's pretty trivial to work with, and since the current underlaying API is not that complex it may not be worth it to work on a more robust solution.

Would love your feedback on this! 👍 