### PR TITLE
Add `Spok::Calendars` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ period.workdays
 Spok.default_calendar = :bovespa
 ```
 
+### Adding custom calendars
+
+If you need to add your own restday calendar, call `Spok.add_calendar` on your
+application boot:
+
+```ruby
+Spok.add_calendar(:custom_calendar, './config/calendars/custom.yml')
+```
+
 ## Documentation
 
 The complete documentation in the RDoc format is available here:

--- a/lib/spok.rb
+++ b/lib/spok.rb
@@ -1,6 +1,8 @@
 require 'spok/version'
 require 'spok/workday'
+require 'spok/calendars'
 
+Spok::Calendars.preload
 # Public: Class responsible for dealing with periods of Dates, considering
 # workdays and restdays.
 class Spok
@@ -12,6 +14,19 @@ class Spok
   mattr_reader :default_calendar
 
   @@default_calendar = :brazil
+
+  # Public: Add a new calendar of holidays to Spok. Calendars are defined with
+  # YAML files containing a single key with its name and an array of dates.
+  #
+  # For reference of builtin calendars, please see the `lib/spok/config` directory.
+  #
+  # name - A String or Symbol with the name of the calendar.
+  # path - A String with the full path for the calendar YAML file.
+  #
+  # Returns nothing.
+  def self.add_calendar(name, path)
+    Spok::Calendars.add(name, path)
+  end
 
   # Public: Parses a string into a Spok.
   #

--- a/lib/spok/calendars.rb
+++ b/lib/spok/calendars.rb
@@ -1,0 +1,47 @@
+require 'set'
+require 'yaml'
+
+class Spok
+  # Internal: Module responsible for loading and collecting calendar definitions
+  # from YAML files.
+  module Calendars
+    @@calendars = {}
+
+    # Public: Add a new calendar.
+    #
+    # name - A String or Symbol with the name of the calendar.
+    # path - A String with the full path for the calendar YAML file.
+    #
+    # Returns nothing.
+    def self.add(name, path)
+      @@calendars[name.to_s] = load(name, path)
+    end
+
+    # Public: Get a calendar.
+    #
+    # name - A String or Symbol with the name of the calendar.
+    #
+    # Raises a `KeyError` if the calender does not exists.
+    # Returns a `Set`.
+    def self.get(name)
+      @@calendars.fetch(name.to_s) { raise KeyError, "Calendar not found: #{name}" }
+    end
+
+    # Internal: Preloads existing calendars into memory.
+    #
+    # Returns nothing.
+    def self.preload
+      Dir[File.expand_path("config/*.yml", __dir__)].each do |path|
+        name = File.basename(path, '.yml')
+        add(name, path)
+      end
+    end
+
+    def self.load(name, path)
+      dates = YAML.safe_load(File.read(path), [Date])
+      Set.new(dates[name.to_s])
+    end
+
+    private_class_method :load
+  end
+end

--- a/lib/spok/workday.rb
+++ b/lib/spok/workday.rb
@@ -1,52 +1,11 @@
 require 'active_support'
 require 'active_support/core_ext'
-require 'set'
-require 'yaml'
 
 class Spok
   # Public: Various methods useful for checking for restdays and workdays.
   # All methods are module methods and should be called on the Spok::Workday
   # module.
   module Workday
-    # Public: Array of available calendars.
-
-    CALENDARS = %i(
-      austria
-      australia
-      austria
-      belgium
-      brazil
-      bovespa
-      canada
-      colombia
-      costa_rica
-      france
-      germany
-      guatemala
-      india
-      indonesia
-      liechtenstein
-      mexico
-      netherlands
-      poland
-      portugal
-      singapore
-      spain
-      ukraine
-      switzerland
-      united_states
-      vietnam
-      spain
-      vietnam
-    )
-
-    # Public: Hash containing all holidays for each available calendar.
-    HOLIDAYS = CALENDARS.map do |calendar|
-      holidays_file = File.open(File.join(File.dirname(__FILE__), "config/#{calendar}.yml"))
-      holidays = YAML.safe_load(holidays_file.read, [Date])
-      [calendar, Set.new(holidays[calendar.to_s])]
-    end.to_h
-
     # Public: Hash containing all weekdays.
     WEEKDAYS = {
       sunday: 0,
@@ -119,7 +78,8 @@ class Spok
     #
     # Returns a boolean.
     def self.holiday?(date, calendar: Spok.default_calendar)
-      HOLIDAYS[calendar].include?(date.to_date)
+      dates = Spok::Calendars.get(calendar)
+      dates.include?(date.to_date)
     end
 
     # Public: Returns the last workday until the informed date.

--- a/spec/fixtures/custom-calendar.yml
+++ b/spec/fixtures/custom-calendar.yml
@@ -1,0 +1,3 @@
+---
+custom_calendar:
+- 2019-01-25

--- a/spec/lib/spok/calendars_spec.rb
+++ b/spec/lib/spok/calendars_spec.rb
@@ -1,14 +1,11 @@
 require 'spec_helper'
-require 'spok/workday'
+require 'spok'
 
-describe 'Spok Calendars' do
-  Spok::Workday::CALENDARS.each do |calendar|
-    it "has valid dates for #{calendar}" do
-      file = File.new(File.join(File.dirname(__FILE__), "../../../lib/spok/config/#{calendar}.yml"))
-      last_day = Date.strptime(file.readlines[-1], '- %Y-%m-%d')
-      valid_calendar = last_day - 365 > Date.today
+describe Spok::Calendars do
+  it 'loads a new calendar' do
+    Spok::Calendars.add(:custom_calendar, File.expand_path('../../fixtures/custom-calendar.yml', __dir__))
 
-      expect(valid_calendar).to eq(true)
-    end
+    expect(Spok::Workday.restday?(Date.new(2019, 01, 25), calendar: :custom_calendar)).to eq(true)
+    expect(Spok::Workday.workday?(Date.new(2019, 01, 25), calendar: :custom_calendar)).to eq(false)
   end
 end


### PR DESCRIPTION
This module will be responsible for dealing with our collection of builtin calendars and provide a way for users to add their own calendars inside their app, without having to add them to the gem and require new releases to RubyGems.

The existing calendars are still here, but in the future we could deprecate them and remove them from the codebase, or tweak to code to avoid loading all 24 files into memory.