### PR TITLE
Remove version restriction from Blunder.

### DIFF
--- a/spok.gemspec
+++ b/spok.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '~> 5.1'
 
-  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3'
 end


### PR DESCRIPTION
I need to do this to not occurs errors on Travis build.

We have a problem with incompatible versions.