### PR TITLE
Hide `Workday` module implementation from the public interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,20 @@ Or install it yourself as:
 
 ### Dealing with workdays
 
-You can use the `Spok::Workday` module to check if a date is either a restday or a workday:
+You can use the Spok to check if a date is either a rest day or a workday:
 
 ```ruby
 require 'spok'
 
-Spok::Workday.workday?(Date.new(2012, 12, 24))
+Spok.restday?(Date.new(2012, 12, 24))
+# => false
+
+Spok.workday?(Date.new(2012, 12, 24))
 # => true
 ```
 
 Spok also supports different calendars for checking if a date is a workday or a
-restday
+restday.
 
 ```ruby
 require 'spok'

--- a/lib/spok.rb
+++ b/lib/spok.rb
@@ -117,6 +117,96 @@ class Spok
     (@start_date..@end_date).to_a.delete_if{ |date| Workday.restday?(date, calendar: calendar) }
   end
 
+  # Public: Checks if a given day is a restday.
+  #
+  # date     - The Date to be checked.
+  # calendar - Symbol informing in which calendar the date will be checked
+  #            (default: :brazil).
+  #
+  # Examples
+  #
+  #   Spok.restday?(Date.new(2012, 8, 6))
+  #   # => false
+  #
+  # Returns a boolean.
+  def self.restday?(date, calendar: Spok.default_calendar)
+    Workday.restday?(date, calendar: calendar)
+  end
+
+  # Public: Checks if a given day is a workday.
+  #
+  # date     - The Date to be checked.
+  # calendar - Symbol informing in which calendar the date will be checked
+  #            (default: :brazil).
+  #
+  # Examples
+  #
+  #   Spok.workday?(Date.new(2012, 8, 6))
+  #   # => true
+  #
+  # Returns a boolean.
+  def self.workday?(date, calendar: Spok.default_calendar)
+    Workday.workday?(date, calendar: calendar)
+  end
+
+  # Public: Checks if a given Date is on a weekend.
+  #
+  # date - The Date to be checked.
+  #
+  # Examples
+  #
+  #   Spok.weekend?(Date.new(2012, 8, 6))
+  #   # => false
+  #
+  # Returns a boolean.
+  def self.weekend?(date)
+    Workday.weekend?(date)
+  end
+
+  # Public: Checks if a given Date is on a holiday.
+  #
+  # date     - The Date to be checked.
+  # calendar - Symbol informing in which calendar the date will be checked
+  #            (default: :brazil).
+  #
+  # Examples
+  #
+  #   Spok.holiday?(Date.new(2012, 5, 1))
+  #   # => true
+  #
+  # Returns a boolean.
+  def self.holiday?(date, calendar: Spok.default_calendar)
+    Workday.holiday?(date, calendar: calendar)
+  end
+
+  # Public: Returns the last workday until the informed date.
+  # It returns the informed date in case it is a workday.
+  #
+  # date     - End Date to check for workdays.
+  # calendar - Symbol informing in which calendar the date will be checked
+  #            (default: :brazil).
+  #
+  # Examples
+  #   Spok.last_workday(Date.new(2012, 10, 21))
+  #   # => #<Date: 2012-10-19 ((2456220j,0s,0n),+0s,2299161j)>
+  def self.last_workday(date, calendar: Spok.default_calendar)
+    Workday.last_workday(date, calendar: calendar)
+  end
+
+  # Public: Returns the next workday starting from the informed date.
+  # It returns the informed date in case it is a workday.
+  #
+  # date     - Start Date to check for workdays.
+  # calendar - Symbol informing in which calendar the date will be checked
+  #            (default: :brazil).
+  #
+  # Examples
+  #   Spok.next_workday(Date.new(2012, 10, 21))
+  #   # => #<Date: 2012-10-19 ((2456220j,0s,0n),+0s,2299161j)>
+  def self.next_workday(date, calendar: Spok.default_calendar)
+    Workday.next_workday(date, calendar: calendar)
+  end
+
   # Public: Returns a Spok containing the same dates in a different calendar.
   #
   # calendar - Symbol informing calendar for new Spok (default: :brazil).

--- a/lib/spok/workday.rb
+++ b/lib/spok/workday.rb
@@ -1,12 +1,13 @@
 require 'active_support'
 require 'active_support/core_ext'
+require 'spok'
 
 class Spok
-  # Public: Various methods useful for checking for restdays and workdays.
+  # Internal: Various methods useful for checking for restdays and workdays.
   # All methods are module methods and should be called on the Spok::Workday
   # module.
   module Workday
-    # Public: Hash containing all weekdays.
+    # Internal: Hash containing all weekdays.
     WEEKDAYS = {
       sunday: 0,
       monday: 1,
@@ -17,7 +18,7 @@ class Spok
       saturday: 6
     }.freeze
 
-    # Public: Checks if a given day is a restday.
+    # Internal: Checks if a given day is a restday.
     #
     # date     - The Date to be checked.
     # calendar - Symbol informing in which calendar the date will be checked
@@ -33,7 +34,7 @@ class Spok
       self.weekend?(date) || self.holiday?(date, calendar: calendar)
     end
 
-    # Public: Checks if a given day is a workday.
+    # Internal: Checks if a given day is a workday.
     #
     # date     - The Date to be checked.
     # calendar - Symbol informing in which calendar the date will be checked
@@ -49,7 +50,7 @@ class Spok
       !restday?(date, calendar: calendar)
     end
 
-    # Public: Checks if a given Date is on a weekend.
+    # Internal: Checks if a given Date is on a weekend.
     #
     # date - The Date to be checked.
     #
@@ -65,7 +66,7 @@ class Spok
       [WEEKDAYS[:saturday], WEEKDAYS[:sunday]].include? weekday
     end
 
-    # Public: Checks if a given Date is on a holiday.
+    # Internal: Checks if a given Date is on a holiday.
     #
     # date     - The Date to be checked.
     # calendar - Symbol informing in which calendar the date will be checked
@@ -82,7 +83,7 @@ class Spok
       dates.include?(date.to_date)
     end
 
-    # Public: Returns the last workday until the informed date.
+    # Internal: Returns the last workday until the informed date.
     # It returns the informed date in case it is a workday.
     #
     # date     - End Date to check for workdays.
@@ -98,7 +99,7 @@ class Spok
       last_workday((date - 1.day), calendar: calendar)
     end
 
-    # Public: Returns the next workday starting from the informed date.
+    # Internal: Returns the next workday starting from the informed date.
     # It returns the informed date in case it is a workday.
     #
     # date     - Start Date to check for workdays.
@@ -112,6 +113,17 @@ class Spok
       return date if workday?(date, calendar: calendar)
 
       next_workday((date + 1.day), calendar: calendar)
+    end
+
+    class << self
+      extend Gem::Deprecate
+
+      deprecate :restday?, 'Spok.restday?', 2020, 12
+      deprecate :workday?, 'Spok.workday?', 2020, 12
+      deprecate :weekend?, 'Spok.weekend?', 2020, 12
+      deprecate :holiday?, 'Spok.holiday?', 2020, 12
+      deprecate :last_workday, 'Spok.last_workday', 2020, 12
+      deprecate :next_workday, 'Spok.next_workday', 2020, 12
     end
   end
 end

--- a/spec/lib/spok_spec.rb
+++ b/spec/lib/spok_spec.rb
@@ -216,4 +216,64 @@ describe Spok do
       expect(default_calendar_was).to eq(:brazil)
     end
   end
+
+  describe '#restday?' do
+    it 'calls for the restday implementation' do
+      date = Date.new(2020, 4, 9)
+
+      expect(Spok::Workday).to receive(:restday?).with(date, calendar: :brazil).and_call_original
+
+      Spok.restday?(date)
+    end
+  end
+
+  describe '.workday?' do
+    it 'calls for the workday implementation' do
+      date = Date.new(2020, 4, 9)
+
+      expect(Spok::Workday).to receive(:workday?).with(date, calendar: :brazil).and_call_original
+
+      Spok.workday?(date)
+    end
+  end
+
+  describe '.weekend?' do
+    it 'calls for the weekend implementation' do
+      date = Date.new(2020, 4, 9)
+
+      expect(Spok::Workday).to receive(:weekend?).with(date).and_call_original
+
+      Spok.weekend?(date)
+    end
+  end
+
+  describe '.holiday?' do
+    it 'calls for the holiday implementation' do
+      date = Date.new(2020, 4, 9)
+
+      expect(Spok::Workday).to receive(:holiday?).with(date, calendar: :brazil).and_call_original
+
+      Spok.holiday?(date)
+    end
+  end
+
+  describe '.last_workday' do
+    it 'calls for the last workday implementation' do
+      date = Date.new(2020, 4, 9)
+
+      expect(Spok::Workday).to receive(:last_workday).with(date, calendar: :brazil).and_call_original
+
+      Spok.last_workday(date)
+    end
+  end
+
+  describe '.next_workday' do
+    it 'calls for the next workday implementation' do
+      date = Date.new(2020, 4, 9)
+
+      expect(Spok::Workday).to receive(:next_workday).with(date, calendar: :brazil).and_call_original
+
+      Spok.next_workday(date)
+    end
+  end
 end


### PR DESCRIPTION
## Objective
Hide `Workday` module implementation from the public interface

### Details
Due to the issue: https://github.com/magnetis/spok/issues/25 reported by @bezelga

It just implements the public interface of the `Workday` module inside the `Spok` interface and it's not a strict change that may cause breaking changes of anybody using `Spok::Workday`.