### PR TITLE
Remove deprecation warnings and create a note about it on README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Or install it yourself as:
 
 ### Dealing with workdays
 
+NOTE: All methods available on `Spok::Workday` now are available on `Spok` interface, `Spok::Workday` still works but we have plans to make `Spok:: Workday` a private resource, you should update your code to rely on `Spok` interface.
+
 You can use the Spok to check if a date is either a rest day or a workday:
 
 ```ruby
@@ -43,7 +45,7 @@ restday.
 ```ruby
 require 'spok'
 
-Spok::Workday.workday?(Date.new(2012, 12, 24), calendar: :bovespa)
+Spok.workday?(Date.new(2012, 12, 24), calendar: :bovespa)
 # => false
 ```
 

--- a/lib/spok/workday.rb
+++ b/lib/spok/workday.rb
@@ -114,16 +114,5 @@ class Spok
 
       next_workday((date + 1.day), calendar: calendar)
     end
-
-    class << self
-      extend Gem::Deprecate
-
-      deprecate :restday?, 'Spok.restday?', 2020, 12
-      deprecate :workday?, 'Spok.workday?', 2020, 12
-      deprecate :weekend?, 'Spok.weekend?', 2020, 12
-      deprecate :holiday?, 'Spok.holiday?', 2020, 12
-      deprecate :last_workday, 'Spok.last_workday', 2020, 12
-      deprecate :next_workday, 'Spok.next_workday', 2020, 12
-    end
   end
 end


### PR DESCRIPTION
## Objective
Remove deprecation warnings and create a note about it on README file

### Details
The deprecation warnings inserted on release 2.1.0 are polluting the output of the methods related to `Spok::Workday` interface.